### PR TITLE
Restore org heading hierarchy in modus-themes config

### DIFF
--- a/emacs-29.d/init.org
+++ b/emacs-29.d/init.org
@@ -1200,11 +1200,11 @@ Modus-themes can help style org mode and I'm using that feature here.
 The theme must be reloaded after setting the values.
 #+begin_src emacs-lisp
   (with-eval-after-load 'modus-themes
-    ;; Subdued headings - no scaling, no background, just subtle color
-    (setq modus-themes-headings '((1 . (regular 1.0))
-  				(2 . (regular 1.0))
-  				(3 . (regular 1.0))
-  				(4 . (regular 1.0))
+    ;; Heading hierarchy: variable-pitch with size/weight contrast across levels
+    (setq modus-themes-headings '((1 . (variable-pitch bold 1.5))
+  				(2 . (variable-pitch bold 1.3))
+  				(3 . (variable-pitch semibold 1.15))
+  				(4 . (variable-pitch semibold 1.1))
                                   (t . (regular 1.0))))
     (modus-themes-load-theme 'modus-vivendi-tinted))
 #+end_src


### PR DESCRIPTION
## Summary
- Replaces the flattened `(regular 1.0)` spec at every level in `modus-themes-headings` with a real hierarchy: `variable-pitch bold 1.5 / 1.3` for H1–H2 and `variable-pitch semibold 1.15 / 1.1` for H3–H4. H5+ stays at `(regular 1.0)`.
- Updates the leading comment so it matches what the form actually does.

## Test plan
- [ ] Open `emacs-29.d/init.org` (or any deeply-nested org file) and confirm H1–H4 are visually distinct in size and weight.
- [ ] Confirm headings render in Palatino (the prose face) and stay correctly styled despite the buffer-wide `variable-pitch-mode` hook.
- [ ] Confirm code blocks, tables, and `org-meta-line` remain monospace via the existing `fixed-pitch` `custom-theme-set-faces` block.

Refs PER-2.