### PR TITLE
feat(emacs): hide emphasis markers with org-appear

### DIFF
--- a/emacs-29.d/init.org
+++ b/emacs-29.d/init.org
@@ -1267,6 +1267,27 @@ and stretched separators. Composes with =olivetti-mode=,
     (global-org-modern-mode 1))
 #+end_src
 
+** Org Appear
+Hides emphasis markers (=*bold*=, =/italic/=, ~=verbatim=~, =~code~=)
+at rest and reveals them automatically when point enters the markup.
+Cuts visual noise without losing the ability to edit the syntax.
+=org-hide-emphasis-markers= is the underlying display toggle that
+=org-appear= rides on — without it the markers are always visible and
+the package has nothing to reveal.
+#+begin_src emacs-lisp
+  (setq org-hide-emphasis-markers t)
+
+  (use-package org-appear
+    :after org
+    :hook (org-mode . org-appear-mode)
+    :custom
+    (org-appear-autoemphasis t)
+    ;; Links read better with their description visible — keep the URL
+    ;; revealed on point so it can still be edited.
+    (org-appear-autolinks t)
+    (org-appear-autosubmarkers t))
+#+end_src
+
 ** Valign
 =variable-pitch-mode= makes glyphs different widths, which causes
 org table columns to drift out of alignment. =valign= post-processes

--- a/emacs-29.d/init.org
+++ b/emacs-29.d/init.org
@@ -1181,6 +1181,9 @@ We'll use scss-mode for both CSS and SCSS files.
     (org-tags-column 0) ;; tags immediately after header text
     (org-auto-align-tags nil) ;; do not align tags between header
     (org-pretty-entities t) ;; use UTF-8 characters
+    ;; Hide *bold*, /italic/, =verbatim=, ~code~ markup at rest. The
+    ;; org-appear package below toggles them back on when point enters.
+    (org-hide-emphasis-markers t)
     ;; Don't interpret underscores as TEX syntax.
     (org-use-sub-superscripts nil)
     (org-attach-id-dir (expand-file-name "assets" org-roam-directory))
@@ -1268,17 +1271,18 @@ and stretched separators. Composes with =olivetti-mode=,
 #+end_src
 
 ** Org Appear
-Hides emphasis markers (=*bold*=, =/italic/=, ~=verbatim=~, =~code~=)
-at rest and reveals them automatically when point enters the markup.
-Cuts visual noise without losing the ability to edit the syntax.
-=org-hide-emphasis-markers= is the underlying display toggle that
-=org-appear= rides on — without it the markers are always visible and
-the package has nothing to reveal.
-#+begin_src emacs-lisp
-  (setq org-hide-emphasis-markers t)
+Reveals hidden markup (emphasis, links, sub/superscripts) when point
+enters it. =org-hide-emphasis-markers= and =org-pretty-entities= are
+set in the =org= block above; =org-link-descriptive= defaults to t.
+Those three are what =org-appear= rides on — without them the
+markers/URLs are always visible and reveal-on-point is a no-op.
 
+Use =:hook= alone (no =:after org=): use-package autoloads
+=org-appear-mode= when the hook fires, and =:after= would defer the
+hook registration past the first =org-mode= invocation, leaving
+reveal silently disabled in the first buffer.
+#+begin_src emacs-lisp
   (use-package org-appear
-    :after org
     :hook (org-mode . org-appear-mode)
     :custom
     (org-appear-autoemphasis t)


### PR DESCRIPTION
## Summary
- Add `org-appear` via straight + use-package, hooked into `org-mode`
- Enable `org-hide-emphasis-markers` (the underlying toggle org-appear rides on)
- Tune so emphasis, links, and sub/superscript markers all reveal when point enters them — emphasis stays hidden at rest for clean reading, links stay editable on point

Closes [PER-5](mention://issue/7ff7abca-d066-459b-85c2-b77a77aa2d40).

## Test plan
- [ ] Run `./install -q` (or `./install -f` if straight needs to fetch the new package) and restart Emacs
- [ ] Open an org buffer with `*bold*`, `/italic/`, `=verbatim=`, `~code~`, and a `[[link][description]]`
- [ ] Confirm markers/URLs are hidden when point is elsewhere and reveal when point enters the span

🤖 Generated with [Claude Code](https://claude.com/claude-code)